### PR TITLE
fix (README) change link for git clone repo to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### Install
 
 ```sh
-git clone git@github.com:hexlet-components/pg-dump-example.git
+git clone https://github.com/hexlet-components/pg-dump-example.git
 cd pg-dump-example
 make # look at the Makefile
 ```


### PR DESCRIPTION
Замена ссылки на репо для клонирования.
Причина - для ssh требуется настраивать ключи. 
если нужно просто скопировать репо себе в учебную машинку, то можно сделать проще.